### PR TITLE
Add TeamCampus prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# TeamCampus Schulplattform
+
+Dies ist ein einfaches Beispiel einer Schulplattform namens **TeamCampus**.
+Die Anwendung basiert auf [Flask](https://flask.palletsprojects.com/) und bietet
+folgende Funktionen:
+
+- Registrierung und Login von Benutzern
+- Erstellen von Teams und Hinzufügen von Kursen zu Teams
+- Abrufen von Teams und Kursen über eine einfache REST-Schnittstelle
+
+## Installation
+
+1. Python 3.12 oder neuer installieren.
+2. Benötigte Abhängigkeiten installieren:
+   ```bash
+   pip install Flask
+   ```
+
+## Nutzung
+
+Die Anwendung befindet sich in `teamcampus/app.py`. Starten Sie den Server mit:
+
+```bash
+python3 teamcampus/app.py
+```
+
+Anschließend stehen folgende Endpunkte zur Verfügung (Beispiele nutzen `curl`):
+
+- **Registrierung**
+  ```bash
+  curl -X POST -H "Content-Type: application/json" \
+       -d '{"username": "max", "password": "geheim"}' \
+       http://localhost:5000/register
+  ```
+- **Login**
+  ```bash
+  curl -X POST -H "Content-Type: application/json" \
+       -d '{"username": "max", "password": "geheim"}' \
+       http://localhost:5000/login
+  ```
+- **Team anlegen**
+  ```bash
+  curl -X POST -H "Content-Type: application/json" \
+       -d '{"name": "Mathe-Team"}' \
+       http://localhost:5000/teams
+  ```
+- **Kurs zu Team hinzufügen**
+  ```bash
+  curl -X POST -H "Content-Type: application/json" \
+       -d '{"course": "Algebra"}' \
+       http://localhost:5000/team/Mathe-Team/courses
+  ```
+- **Alle Teams auflisten**
+  ```bash
+  curl http://localhost:5000/teams
+  ```
+
+Diese Plattform ist nur als Beispiel gedacht und nutzt keinen persistenten
+Speicher. Für eine produktive Nutzung sollten Datenbank, Authentifizierung und
+Sicherheit erweitert werden.

--- a/teamcampus/app.py
+++ b/teamcampus/app.py
@@ -1,0 +1,69 @@
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+users = {}
+teams = {}
+
+@app.route('/')
+def index():
+    return jsonify({'message': 'Welcome to TeamCampus'})
+
+@app.route('/register', methods=['POST'])
+def register():
+    data = request.get_json()
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'Username and password required'}), 400
+    if username in users:
+        return jsonify({'error': 'User exists'}), 400
+    users[username] = {'password': password, 'team': None}
+    return jsonify({'message': 'User registered'}), 201
+
+@app.route('/login', methods=['POST'])
+def login():
+    data = request.get_json()
+    username = data.get('username')
+    password = data.get('password')
+    user = users.get(username)
+    if user and user['password'] == password:
+        return jsonify({'message': 'Login successful'})
+    return jsonify({'error': 'Invalid credentials'}), 401
+
+@app.route('/teams', methods=['GET'])
+def list_teams():
+    return jsonify({'teams': list(teams.keys())})
+
+@app.route('/teams', methods=['POST'])
+def create_team():
+    data = request.get_json()
+    name = data.get('name')
+    if not name:
+        return jsonify({'error': 'Team name required'}), 400
+    if name in teams:
+        return jsonify({'error': 'Team exists'}), 400
+    teams[name] = {'courses': []}
+    return jsonify({'message': 'Team created'}), 201
+
+@app.route('/team/<team_name>', methods=['GET'])
+def get_team(team_name):
+    team = teams.get(team_name)
+    if not team:
+        return jsonify({'error': 'Team not found'}), 404
+    return jsonify({'team': team_name, 'courses': team['courses']})
+
+@app.route('/team/<team_name>/courses', methods=['POST'])
+def add_course(team_name):
+    team = teams.get(team_name)
+    if not team:
+        return jsonify({'error': 'Team not found'}), 404
+    data = request.get_json()
+    course = data.get('course')
+    if not course:
+        return jsonify({'error': 'Course name required'}), 400
+    team['courses'].append(course)
+    return jsonify({'message': 'Course added'}), 201
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- implement minimal TeamCampus Schulplattform using Flask
- add usage documentation and API examples in README

## Testing
- `pip install Flask`


------
https://chatgpt.com/codex/tasks/task_e_68581a97b5108328a4da6b224c3e60fb